### PR TITLE
Migrate dependencies to deps.edn and update shadow-cljs config

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,30 @@
+{:paths ["src" "test" "../monopoly/src"]
+
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        
+        ;; Build Tool
+        thheller/shadow-cljs {:mvn/version "2.25.8"}
+        
+        ;; UI Libraries
+        reagent/reagent {:mvn/version "1.1.1"}
+        re-frame/re-frame {:mvn/version "1.4.2"}
+        re-com/re-com {:mvn/version "2.13.2"}
+        
+        ;; Routing
+        bidi/bidi {:mvn/version "2.1.6"}
+        clj-commons/pushy {:mvn/version "0.3.10"}
+        
+        ;; CSS
+        garden/garden {:mvn/version "1.3.10"}
+        net.dhleong/spade {:mvn/version "1.1.0"}
+        
+        ;; Development Tools
+        binaryage/devtools {:mvn/version "1.0.6"}
+        re-frisk/re-frisk {:mvn/version "1.6.0"}
+        cider/cider-nrepl {:mvn/version "0.44.0"}
+        
+        ;; Core Libraries
+        org.clojure/core.async {:mvn/version "1.6.681"}
+        org.clojure/core.memoize {:mvn/version "1.1.266"}}
+
+ :aliases {}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,24 +1,8 @@
-{:nrepl {:port 8777}
+{:deps true
+
+ :nrepl {:port 8777}
 
  :jvm-opts ["-Xmx1G"]
-
- :source-paths ["src" "test" "../monopoly/src"]
-
- :dependencies
- [[reagent "1.1.1"]
-  [re-frame "1.4.2"]
-  [re-com "2.13.2"]
-  [bidi "2.1.6"]
-  [clj-commons/pushy "0.3.10"]
-  [garden "1.3.10"]
-  [net.dhleong/spade "1.1.0"]
-
-  [binaryage/devtools "1.0.6"]
-  [re-frisk "1.6.0"]
-  [cider/cider-nrepl "0.44.0"]
-  
-  [org.clojure/core.async "1.6.681"]
-  [org.clojure/core.memoize "1.1.266"]]
 
  :dev-http
  {8280 "resources/public"


### PR DESCRIPTION
Moved project dependencies from shadow-cljs.edn to a new deps.edn file, enabling :deps true in shadow-cljs.edn for dependency management via tools.deps. This streamlines dependency handling and aligns with Clojure's recommended practices.