### PR TITLE
Multi-threaded bulk simulation via Web Workers

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -36,6 +36,7 @@
       jmshelby.monopoly-web is a JavaScript app. Please enable JavaScript to continue.
     </noscript>
     <div id="app"></div>
+    <script src="/js/compiled/shared.js"></script>
     <script src="/js/compiled/app.js"></script>
   </body>
 </html>

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,7 +14,13 @@
    :output-dir "resources/public/js/compiled"
    :asset-path "/js/compiled"
    :modules
-   {:app {:init-fn jmshelby.monopoly-web.core/init}}
+   {:shared {:entries []}
+    :app    {:init-fn    jmshelby.monopoly-web.core/init
+             :depends-on #{:shared}}
+    :worker-simulations
+    {:init-fn    jmshelby.monopoly-web.worker.simulations/init
+     :depends-on #{:shared}
+     :web-worker true}}
    :compiler-options
    {:warnings {:redef false}}
    :devtools

--- a/src/jmshelby/monopoly_web/core.cljs
+++ b/src/jmshelby/monopoly_web/core.cljs
@@ -2,6 +2,7 @@
   (:require
    [reagent.dom :as rdom]
    [re-frame.core :as re-frame]
+   [cljs.reader :as reader]
    [clojure.core.async :as async]
    [jmshelby.monopoly-web.events :as events]
    [jmshelby.monopoly-web.routes :as routes]
@@ -21,41 +22,59 @@
     (rdom/unmount-component-at-node root-el)
     (rdom/render [views/simple-main-panel] root-el)))
 
-(defn- wait-for-next-game
-  [chan completion-event]
-  (async/go
-    (when-let [game (async/<! chan)]
-      (println "new game ready, dispatching ...")
-      (re-frame/dispatch [completion-event game])
-      (println "new game ready, dispatching ...continuing"))))
+;; Bulk simulation runs each game in a Web Worker so CPU-bound games execute
+;; in parallel across cores instead of one-at-a-time on the main JS thread.
+(def ^:const WORKER-SCRIPT "/js/compiled/worker-simulations.js")
+
+(defn- worker-count
+  "Number of workers to spawn: one per core, minus one to keep the main thread
+  responsive. Never more than the number of games, never less than one."
+  [num-games]
+  (let [cores (or (.-hardwareConcurrency js/navigator) 4)]
+    (max 1 (min num-games (dec cores)))))
+
+(defn- split-games
+  "Split `num-games` into `n` chunk sizes, spreading the remainder over the
+  first few chunks. Returns a seq of positive chunk sizes."
+  [num-games n]
+  (let [base  (quot num-games n)
+        extra (rem num-games n)]
+    (->> (range n)
+         (map #(+ base (if (< % extra) 1 0)))
+         (remove zero?))))
 
 ;; An event to start a bulk simulation of monopoly games
 (re-frame/reg-fx
  :monopoly/simulation
  (fn [{:keys [num-games num-players safety-threshold started-event completion-event]}]
-   (let [num-players (or num-players 4)
+   (let [num-players      (or num-players 4)
          safety-threshold (or safety-threshold 1000)
-         output-ch (core-sim/run-simulation num-games
-                                            num-players
-                                            safety-threshold)]
-     ;; Dispatch to save the channel
+         chunks           (split-games num-games (worker-count num-games))
+         workers
+         (mapv
+          (fn [chunk]
+            (let [w (js/Worker. WORKER-SCRIPT)]
+              ;; Each worker streams back batches of finished game analyses
+              (set! (.-onmessage w)
+                    (fn [e]
+                      (let [msg (reader/read-string (.-data e))]
+                        (when (= :results (:type msg))
+                          (re-frame/dispatch [completion-event (:results msg)])))))
+              (.postMessage w (pr-str {:games            chunk
+                                       :num-players      num-players
+                                       :safety-threshold safety-threshold}))
+              w))
+          chunks)]
+     ;; Hand the workers back so they can be terminated on stop
      (when started-event
-       (re-frame/dispatch [started-event output-ch]))
-     ;; Prime the compute cycle with the first game
-     (wait-for-next-game output-ch completion-event))))
-
-(re-frame/reg-fx
- :monopoly/simulation-continue
- (fn [{:keys [output-ch completion-event]}]
-   ;; Just another take and dispatch when ready
-   (wait-for-next-game output-ch completion-event)))
+       (re-frame/dispatch [started-event workers])))))
 
 (re-frame/reg-fx
  :monopoly/simulation-stop
- (fn [output-ch]
-   ;; Close the channel, and games can't continue
-   (println "closed channel!")
-   (async/close! output-ch)))
+ (fn [workers]
+   ;; Terminate all workers so in-flight games stop producing results
+   (doseq [w workers]
+     (.terminate w))))
 
 ;; Custom player simulation effect
 (re-frame/reg-fx

--- a/src/jmshelby/monopoly_web/events.cljs
+++ b/src/jmshelby/monopoly_web/events.cljs
@@ -183,50 +183,45 @@
       :monopoly/simulation {:num-games num-games
                             :num-players player-count
                             :started-event ::bulk-sim-started
-                            :completion-event ::bulk-sim-game-finished}})))
+                            :completion-event ::bulk-sim-games-finished}})))
 
 (re-frame/reg-event-fx
  ::stop-bulk-simulation
  (fn [{:keys [db]} _]
    {:db (assoc-in db [:bulk-simulation :running?] false)
-    :monopoly/simulation-stop (get-in db [:bulk-simulation :output-chan])}))
+    :monopoly/simulation-stop (get-in db [:bulk-simulation :workers])}))
 
 (re-frame/reg-event-db
  ::bulk-sim-started
- (fn [db [_ output-ch]]
-   (assoc-in db [:bulk-simulation :output-chan] output-ch)))
+ (fn [db [_ workers]]
+   (assoc-in db [:bulk-simulation :workers] workers)))
 
-;; When bulk monopoly simulation is running, this gets fired every time
-;; a new game is complete and ready to update the analysis screen
+;; When bulk monopoly simulation is running, this gets fired every time a
+;; worker delivers a batch of finished games, ready to update the analysis
+;; screen. Workers push results autonomously, so there is no continuation
+;; effect to request the next game.
 (re-frame/reg-event-fx
- ::bulk-sim-game-finished
- (fn [{:keys [db]} [_ game]]
-   (println "registering new game results in db...")
+ ::bulk-sim-games-finished
+ (fn [{:keys [db]} [_ games]]
    (let [start-time (get-in db [:bulk-simulation :start-time])
          duration-ms (time/elapsed-ms start-time
                                       (time/now))
-         output-ch (get-in db [:bulk-simulation :output-chan])
          total-games (get-in db [:bulk-simulation :total-games])
          prev-results (get-in db [:bulk-simulation :results])
-         new-results (conj prev-results game)
+         new-results (into prev-results games)
          new-stats (core-sim/calculate-statistics new-results
                                                   (count new-results)
                                                   duration-ms)
-         more-games? (not= total-games (count new-results))]
+         more-games? (< (count new-results) total-games)]
 
-     (merge
-      {:db (-> db
-              ;; Recalc new bulk stats with this additional game
-               (assoc-in [:bulk-simulation :stats] new-stats)
-              ;; Keep that game's results
-               (assoc-in [:bulk-simulation :results] new-results)
-              ;; Update progress counter
-               (assoc-in [:bulk-simulation :progress] (count new-results))
-               (assoc-in [:bulk-simulation :running?] more-games?))}
-      ;; If there are more games needed, we need to invoke an fx for that
-      (when more-games?
-        {:monopoly/simulation-continue {:output-ch output-ch
-                                        :completion-event ::bulk-sim-game-finished}})))))
+     {:db (-> db
+             ;; Recalc bulk stats with this batch of games
+              (assoc-in [:bulk-simulation :stats] new-stats)
+             ;; Keep these games' results
+              (assoc-in [:bulk-simulation :results] new-results)
+             ;; Update progress counter
+              (assoc-in [:bulk-simulation :progress] (count new-results))
+              (assoc-in [:bulk-simulation :running?] more-games?))})))
 
 
 (re-frame/reg-event-db

--- a/src/jmshelby/monopoly_web/worker/simulations.cljs
+++ b/src/jmshelby/monopoly_web/worker/simulations.cljs
@@ -1,0 +1,40 @@
+(ns jmshelby.monopoly-web.worker.simulations
+  "Web Worker entry point for bulk simulations. Runs a chunk of games to
+  completion off the main thread and streams analyses back via postMessage.
+
+  Inbound message (from main thread):
+    {:games N :num-players P :safety-threshold T}
+  Outbound messages (to main thread):
+    {:type \"results\" :results [analysis ...]}  ;; one per BATCH games
+    {:type \"done\"}                              ;; chunk finished"
+  (:require [jmshelby.monopoly.core :as mono-core]
+            [jmshelby.monopoly.simulation :as mono-sim]))
+
+(def ^:const BATCH
+  "Number of game analyses to accumulate before posting a batch back to the
+  main thread. Batching keeps postMessage + re-frame dispatch overhead from
+  dominating once games stream back in parallel."
+  25)
+
+(defn run-chunk
+  "Run `games` complete simulations, posting analyses back in batches of BATCH."
+  [{:keys [games num-players safety-threshold]}]
+  (let [buf    (volatile! [])
+        flush! (fn []
+                 (when (seq @buf)
+                   (.postMessage js/self (clj->js {:type :results :results @buf}))
+                   (vreset! buf [])))]
+    (dotimes [_ games]
+      (let [analysis (-> (mono-core/rand-game-end-state num-players safety-threshold)
+                         (mono-sim/analyze-game-outcome))]
+        (vswap! buf conj analysis)
+        (when (>= (count @buf) BATCH)
+          (flush!))))
+    (flush!)
+    (.postMessage js/self (clj->js {:type :done}))))
+
+(defn on-message [event]
+  (run-chunk (js->clj (.-data event) :keywordize-keys true)))
+
+(defn init []
+  (set! (.-onmessage js/self) on-message))

--- a/src/jmshelby/monopoly_web/worker/simulations.cljs
+++ b/src/jmshelby/monopoly_web/worker/simulations.cljs
@@ -21,6 +21,31 @@
   dominating once games stream back in parallel."
   25)
 
+(def ^:const SAMPLE-CAP
+  "Per-game cap on the raw auction-transaction vectors that analyze-game-outcome
+  attaches. These vectors are only ever used to render a handful of sample rows
+  (calculate-statistics takes 5 games x 10 txns), but for long games they can be
+  large. Serializing thousands of them across the worker boundary is what spikes
+  main-thread memory, so we keep only a few entries per game here. Every numeric
+  statistic is derived from separate scalar count fields and is unaffected."
+  5)
+
+(def ^:private sample-keys
+  "Display-only, unbounded fields on each analysis to trim before serializing."
+  [:auction-initiated-transactions
+   :auction-completed-transactions
+   :auction-passed-transactions
+   :property-declined-auctions
+   :bankruptcy-auctions])
+
+(defn- slim
+  "Cap the display-only transaction vectors so message payloads (and retained
+  results) stay small. Leaves all scalar/count fields untouched."
+  [analysis]
+  (reduce (fn [a k] (update a k #(into [] (take SAMPLE-CAP) %)))
+          analysis
+          sample-keys))
+
 (defn- post! [msg]
   (.postMessage js/self (pr-str msg)))
 
@@ -34,7 +59,8 @@
                    (vreset! buf [])))]
     (dotimes [_ games]
       (let [analysis (-> (mono-core/rand-game-end-state num-players safety-threshold)
-                         (mono-sim/analyze-game-outcome))]
+                         (mono-sim/analyze-game-outcome)
+                         (slim))]
         (vswap! buf conj analysis)
         (when (>= (count @buf) BATCH)
           (flush!))))

--- a/src/jmshelby/monopoly_web/worker/simulations.cljs
+++ b/src/jmshelby/monopoly_web/worker/simulations.cljs
@@ -2,12 +2,17 @@
   "Web Worker entry point for bulk simulations. Runs a chunk of games to
   completion off the main thread and streams analyses back via postMessage.
 
+  Messages are EDN strings (pr-str / read-string) so Clojure data round-trips
+  losslessly across the worker boundary (keyword values and exact integers
+  survive, unlike clj->js/js->clj).
+
   Inbound message (from main thread):
     {:games N :num-players P :safety-threshold T}
   Outbound messages (to main thread):
-    {:type \"results\" :results [analysis ...]}  ;; one per BATCH games
-    {:type \"done\"}                              ;; chunk finished"
-  (:require [jmshelby.monopoly.core :as mono-core]
+    {:type :results :results [analysis ...]}  ;; one per BATCH games
+    {:type :done}                             ;; chunk finished"
+  (:require [cljs.reader :as reader]
+            [jmshelby.monopoly.core :as mono-core]
             [jmshelby.monopoly.simulation :as mono-sim]))
 
 (def ^:const BATCH
@@ -16,13 +21,16 @@
   dominating once games stream back in parallel."
   25)
 
+(defn- post! [msg]
+  (.postMessage js/self (pr-str msg)))
+
 (defn run-chunk
   "Run `games` complete simulations, posting analyses back in batches of BATCH."
   [{:keys [games num-players safety-threshold]}]
   (let [buf    (volatile! [])
         flush! (fn []
                  (when (seq @buf)
-                   (.postMessage js/self (clj->js {:type :results :results @buf}))
+                   (post! {:type :results :results @buf})
                    (vreset! buf [])))]
     (dotimes [_ games]
       (let [analysis (-> (mono-core/rand-game-end-state num-players safety-threshold)
@@ -31,10 +39,10 @@
         (when (>= (count @buf) BATCH)
           (flush!))))
     (flush!)
-    (.postMessage js/self (clj->js {:type :done}))))
+    (post! {:type :done})))
 
 (defn on-message [event]
-  (run-chunk (js->clj (.-data event) :keywordize-keys true)))
+  (run-chunk (reader/read-string (.-data event))))
 
 (defn init []
   (set! (.-onmessage js/self) on-message))

--- a/src/jmshelby/monopoly_web/worker/simulations.cljs
+++ b/src/jmshelby/monopoly_web/worker/simulations.cljs
@@ -21,31 +21,6 @@
   dominating once games stream back in parallel."
   25)
 
-(def ^:const SAMPLE-CAP
-  "Per-game cap on the raw auction-transaction vectors that analyze-game-outcome
-  attaches. These vectors are only ever used to render a handful of sample rows
-  (calculate-statistics takes 5 games x 10 txns), but for long games they can be
-  large. Serializing thousands of them across the worker boundary is what spikes
-  main-thread memory, so we keep only a few entries per game here. Every numeric
-  statistic is derived from separate scalar count fields and is unaffected."
-  5)
-
-(def ^:private sample-keys
-  "Display-only, unbounded fields on each analysis to trim before serializing."
-  [:auction-initiated-transactions
-   :auction-completed-transactions
-   :auction-passed-transactions
-   :property-declined-auctions
-   :bankruptcy-auctions])
-
-(defn- slim
-  "Cap the display-only transaction vectors so message payloads (and retained
-  results) stay small. Leaves all scalar/count fields untouched."
-  [analysis]
-  (reduce (fn [a k] (update a k #(into [] (take SAMPLE-CAP) %)))
-          analysis
-          sample-keys))
-
 (defn- post! [msg]
   (.postMessage js/self (pr-str msg)))
 
@@ -59,8 +34,7 @@
                    (vreset! buf [])))]
     (dotimes [_ games]
       (let [analysis (-> (mono-core/rand-game-end-state num-players safety-threshold)
-                         (mono-sim/analyze-game-outcome)
-                         (slim))]
+                         (mono-sim/analyze-game-outcome))]
         (vswap! buf conj analysis)
         (when (>= (count @buf) BATCH)
           (flush!))))


### PR DESCRIPTION
## Summary

Makes the **bulk simulation** mode multi-threaded using Web Workers. Each Monopoly game is CPU-bound; today they run one-at-a-time on the single JS thread (the `core.async/pipeline` is just cooperative scheduling in the browser). This spawns a pool of `hardwareConcurrency - 1` workers that run games in parallel and stream finished game analyses back to the main thread.

The bulk path is a clean fit: a game is fully specified by serializable data (`num-players` + `safety-threshold`, with the built-in `dumb-player/decide` strategy), and `analyze-game-outcome` returns a plain data map. No core-engine changes required.

Scope: **bulk sim only** — Player Lab (custom-player SCI path) stays single-threaded.

## Approach (incremental commits)

1. shadow-cljs: split `:app` into `:shared` / `:app` / `:worker-simulations` (`:web-worker true`) modules
2. index.html: load `shared.js` before `app.js`
3. New worker namespace: runs a chunk of games, posts batched results
4. core.cljs: worker-pool producer effect (split games across workers), stop via `.terminate`
5. events.cljs: batch-accepting `bulk-sim-games-finished`, store workers vector

Worker count = `cores - 1` (keeps a core free for the UI). Results are posted in batches (~25 games) so the main-thread stats recompute doesn't become the new bottleneck.

## Status

Draft — built up stage-by-stage. Will mark ready after end-to-end verification (functional run, observed multi-core CPU usage, stop button, release build).